### PR TITLE
Fix CLI

### DIFF
--- a/backend/src/keychain/modules/routers/api/v1/password/password.py
+++ b/backend/src/keychain/modules/routers/api/v1/password/password.py
@@ -95,7 +95,7 @@ async def create_password(
     """
     password_dao = PasswordDAO(db, user.id)
     try:
-        password = await password_dao.create(password.name, user.id, password.image_url)
+        password = await password_dao.create(password.name, password.image_url)
     except ValueError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
     except Exception as e:

--- a/backend/src/keychain/services/daos/password.py
+++ b/backend/src/keychain/services/daos/password.py
@@ -73,17 +73,16 @@ class PasswordDAO(BaseDAO[Password]):
 
         return password
 
-    async def create(self, name: str, user_id: int, image_url: str | None = None) -> Password:
+    async def create(self, name: str, image_url: str | None = None) -> Password:
         """Create a new password in the database.
 
-        Creates a new password with the provided name and user_id. The image_url
+        Creates a new password with the provided name and user_id from the DAO. The image_url
         is optional and will default to "/static/i/no-photo.png" if not provided.
         After creation, the password is refreshed from the database to ensure all
         generated fields (e.g., ID, timestamps) are populated.
 
         Args:
             name: The name of the password to create.
-            user_id: The unique identifier of the user who owns the password.
             image_url: The URL of the image associated with the password.
 
         Returns:
@@ -93,7 +92,7 @@ class PasswordDAO(BaseDAO[Password]):
         async with self.db_client.session() as session:
             password = Password(
                 name=name,
-                user_id=user_id,
+                user_id=self.user_id,
                 image_url=image_url,
             )
             session.add(password)

--- a/backend/src/keychain/utils/cli/db_client/db_client.py
+++ b/backend/src/keychain/utils/cli/db_client/db_client.py
@@ -6,7 +6,6 @@ __all__ = ["db_client"]
 import click
 
 from keychain.config import AppConfig
-from keychain.services.daos import FieldDAO, PasswordDAO, UserDAO
 from keychain.services.db_client.client import DBClient
 
 from .field import field
@@ -25,13 +24,7 @@ def db_client(ctx: click.Context) -> None:
     """
     ctx.ensure_object(dict)
     config = AppConfig.get_or_create()
-    db_client_instance = DBClient(config)
-    user_dao = UserDAO(db_client_instance)
-    password_dao = PasswordDAO(db_client_instance)
-    field_dao = FieldDAO(db_client_instance)
-    ctx.obj["user_dao"] = user_dao
-    ctx.obj["password_dao"] = password_dao
-    ctx.obj["field_dao"] = field_dao
+    ctx.obj["db_client_instance"] = DBClient(config)
 
 
 db_client.add_command(user)

--- a/backend/src/keychain/utils/cli/db_client/field.py
+++ b/backend/src/keychain/utils/cli/db_client/field.py
@@ -11,6 +11,7 @@ from keychain.config import AppConfig
 from keychain.modules.routers.models.response import FieldGetResponseModel, FieldGetResponseModelSimple
 from keychain.services.cryptography.client import CryptographyClient
 from keychain.services.daos import FieldDAO
+from keychain.services.db_client.client import DBClient
 
 
 @click.group(help="CLI for managing fields of the Keychain Application.")
@@ -28,11 +29,12 @@ def field(ctx: click.Context) -> None:
 @field.command(help="Create a new field")
 @click.option("--name", prompt="Enter the field name", help="The name of the field")
 @click.option("--value", prompt="Enter the field value", help="The value of the field", hide_input=True)
+@click.option("--user-id", prompt="Enter the user ID", help="The ID of the user who owns the field", type=int)
 @click.option(
     "--password-id", prompt="Enter the password ID", help="The ID of the password that owns the field", type=int
 )
 @click.pass_context
-def create_field(ctx: click.Context, name: str, value: str, password_id: int) -> None:
+def create_field(ctx: click.Context, name: str, value: str, user_id: int, password_id: int) -> None:
     """Create a new field in the database.
 
     This command prompts for a field name, value, and password ID, creates a new field
@@ -42,10 +44,13 @@ def create_field(ctx: click.Context, name: str, value: str, password_id: int) ->
         ctx: Click context object containing the field DAO.
         name: The name of the field to create.
         value: The value of the field to create (will be encrypted before storage).
+        user_id: The unique identifier of the user who owns the field.
         password_id: The unique identifier of the password that owns the field.
 
     """
     field_dao: FieldDAO = ctx.obj["field_dao"]
+    db_client: DBClient = ctx.obj["db_client_instance"]
+    field_dao = FieldDAO(db_client, user_id)
     field = asyncio.run(field_dao.create(name, value, password_id))
     field_response = FieldGetResponseModel.model_validate(field)
     click.echo(field_response.model_dump_json(indent=2))
@@ -53,8 +58,9 @@ def create_field(ctx: click.Context, name: str, value: str, password_id: int) ->
 
 @field.command(help="Get a field by ID")
 @click.option("--field-id", prompt="Enter the field ID", help="The ID of the field", type=int)
+@click.option("--user-id", prompt="Enter the user ID", help="The ID of the user who owns the field", type=int)
 @click.pass_context
-def get_field(ctx: click.Context, field_id: int) -> None:
+def get_field(ctx: click.Context, field_id: int, user_id: int) -> None:
     """Retrieve a field from the database by its ID.
 
     This command fetches a field record by ID and outputs the field information
@@ -63,9 +69,12 @@ def get_field(ctx: click.Context, field_id: int) -> None:
     Args:
         ctx: Click context object containing the field DAO.
         field_id: The unique identifier of the field to retrieve.
+        user_id: The unique identifier of the user who owns the field.
 
     """
     field_dao: FieldDAO = ctx.obj["field_dao"]
+    db_client: DBClient = ctx.obj["db_client_instance"]
+    field_dao = FieldDAO(db_client, user_id)
     field = asyncio.run(field_dao.get_by_id(field_id))
     field_response = FieldGetResponseModel.model_validate(field)
     click.echo(field_response.model_dump_json(indent=2))
@@ -74,8 +83,9 @@ def get_field(ctx: click.Context, field_id: int) -> None:
 @field.command(help="Update a field by ID")
 @click.option("--field-id", prompt="Enter the field ID", help="The ID of the field", type=int)
 @click.option("--value", prompt="Enter the new value", help="The new value of the field", hide_input=True)
+@click.option("--user-id", prompt="Enter the user ID", help="The ID of the user who owns the field", type=int)
 @click.pass_context
-def update_field(ctx: click.Context, field_id: int, value: str) -> None:
+def update_field(ctx: click.Context, field_id: int, value: str, user_id: int) -> None:
     """Update a field's value in the database.
 
     This command updates the value of an existing field identified by its ID
@@ -86,9 +96,12 @@ def update_field(ctx: click.Context, field_id: int, value: str) -> None:
         ctx: Click context object containing the field DAO.
         field_id: The unique identifier of the field to update.
         value: The new value to assign to the field (will be encrypted before storage).
+        user_id: The unique identifier of the user who owns the field.
 
     """
     field_dao: FieldDAO = ctx.obj["field_dao"]
+    db_client: DBClient = ctx.obj["db_client_instance"]
+    field_dao = FieldDAO(db_client, user_id)
     field = asyncio.run(field_dao.update(field_id, value))
     field_response = FieldGetResponseModel.model_validate(field)
     click.echo(field_response.model_dump_json(indent=2))
@@ -96,8 +109,9 @@ def update_field(ctx: click.Context, field_id: int, value: str) -> None:
 
 @field.command(help="Delete a field by ID")
 @click.option("--field-id", prompt="Enter the field ID", help="The ID of the field", type=int)
+@click.option("--user-id", prompt="Enter the user ID", help="The ID of the user who owns the field", type=int)
 @click.pass_context
-def delete_field(ctx: click.Context, field_id: int) -> None:
+def delete_field(ctx: click.Context, field_id: int, user_id: int) -> None:
     """Delete a field from the database by its ID.
 
     This command permanently marks a field record as deleted in the database.
@@ -106,16 +120,20 @@ def delete_field(ctx: click.Context, field_id: int) -> None:
     Args:
         ctx: Click context object containing the field DAO.
         field_id: The unique identifier of the field to delete.
+        user_id: The unique identifier of the user who owns the field.
 
     """
     field_dao: FieldDAO = ctx.obj["field_dao"]
+    db_client: DBClient = ctx.obj["db_client_instance"]
+    field_dao = FieldDAO(db_client, user_id)
     asyncio.run(field_dao.delete(field_id))
     click.echo(f"Field with id {field_id} deleted successfully")
 
 
 @field.command(help="List all fields")
+@click.option("--user-id", prompt="Enter the user ID", help="The ID of the user who owns the field", type=int)
 @click.pass_context
-def list_fields(ctx: click.Context) -> None:
+def list_fields(ctx: click.Context, user_id: int) -> None:
     """List all fields in the database.
 
     This command retrieves all fields from the database and outputs them
@@ -123,9 +141,12 @@ def list_fields(ctx: click.Context) -> None:
 
     Args:
         ctx: Click context object containing the field DAO.
+        user_id: The unique identifier of the user who owns the field.
 
     """
     field_dao: FieldDAO = ctx.obj["field_dao"]
+    db_client: DBClient = ctx.obj["db_client_instance"]
+    field_dao = FieldDAO(db_client, user_id)
     fields = asyncio.run(field_dao.get_all())
     field_responses = [FieldGetResponseModelSimple.model_validate(field) for field in fields]
     click.echo(json.dumps([field.model_dump() for field in field_responses], indent=2))

--- a/backend/src/keychain/utils/cli/db_client/field.py
+++ b/backend/src/keychain/utils/cli/db_client/field.py
@@ -48,7 +48,6 @@ def create_field(ctx: click.Context, name: str, value: str, user_id: int, passwo
         password_id: The unique identifier of the password that owns the field.
 
     """
-    field_dao: FieldDAO = ctx.obj["field_dao"]
     db_client: DBClient = ctx.obj["db_client_instance"]
     field_dao = FieldDAO(db_client, user_id)
     field = asyncio.run(field_dao.create(name, value, password_id))
@@ -72,7 +71,6 @@ def get_field(ctx: click.Context, field_id: int, user_id: int) -> None:
         user_id: The unique identifier of the user who owns the field.
 
     """
-    field_dao: FieldDAO = ctx.obj["field_dao"]
     db_client: DBClient = ctx.obj["db_client_instance"]
     field_dao = FieldDAO(db_client, user_id)
     field = asyncio.run(field_dao.get_by_id(field_id))
@@ -99,7 +97,6 @@ def update_field(ctx: click.Context, field_id: int, value: str, user_id: int) ->
         user_id: The unique identifier of the user who owns the field.
 
     """
-    field_dao: FieldDAO = ctx.obj["field_dao"]
     db_client: DBClient = ctx.obj["db_client_instance"]
     field_dao = FieldDAO(db_client, user_id)
     field = asyncio.run(field_dao.update(field_id, value))
@@ -123,7 +120,6 @@ def delete_field(ctx: click.Context, field_id: int, user_id: int) -> None:
         user_id: The unique identifier of the user who owns the field.
 
     """
-    field_dao: FieldDAO = ctx.obj["field_dao"]
     db_client: DBClient = ctx.obj["db_client_instance"]
     field_dao = FieldDAO(db_client, user_id)
     asyncio.run(field_dao.delete(field_id))
@@ -144,7 +140,6 @@ def list_fields(ctx: click.Context, user_id: int) -> None:
         user_id: The unique identifier of the user who owns the field.
 
     """
-    field_dao: FieldDAO = ctx.obj["field_dao"]
     db_client: DBClient = ctx.obj["db_client_instance"]
     field_dao = FieldDAO(db_client, user_id)
     fields = asyncio.run(field_dao.get_all())

--- a/backend/src/keychain/utils/cli/db_client/password.py
+++ b/backend/src/keychain/utils/cli/db_client/password.py
@@ -39,7 +39,6 @@ def create_password(ctx: click.Context, name: str, user_id: int, image_url: str 
         image_url: Optional URL of the image associated with the password.
 
     """
-    password_dao: PasswordDAO = ctx.obj["password_dao"]
     db_client: DBClient = ctx.obj["db_client_instance"]
     password_dao = PasswordDAO(db_client, user_id)
     password = asyncio.run(password_dao.create(name, image_url))
@@ -63,7 +62,6 @@ def get_password(ctx: click.Context, password_id: int, user_id: int) -> None:
         user_id: The unique identifier of the user who owns the password.
 
     """
-    password_dao: PasswordDAO = ctx.obj["password_dao"]
     db_client: DBClient = ctx.obj["db_client_instance"]
     password_dao = PasswordDAO(db_client, user_id)
     password = asyncio.run(password_dao.get_by_id(password_id))
@@ -91,7 +89,6 @@ def update_password(ctx: click.Context, password_id: int, name: str, image_url: 
         user_id: The unique identifier of the user who owns the password.
 
     """
-    password_dao: PasswordDAO = ctx.obj["password_dao"]
     db_client: DBClient = ctx.obj["db_client_instance"]
     password_dao = PasswordDAO(db_client, user_id)
     password = asyncio.run(password_dao.update(password_id, name, image_url))
@@ -115,7 +112,6 @@ def delete_password(ctx: click.Context, password_id: int, user_id: int) -> None:
         user_id: The unique identifier of the user who owns the password.
 
     """
-    password_dao: PasswordDAO = ctx.obj["password_dao"]
     db_client: DBClient = ctx.obj["db_client_instance"]
     password_dao = PasswordDAO(db_client, user_id)
     asyncio.run(password_dao.delete(password_id))
@@ -136,7 +132,6 @@ def list_passwords(ctx: click.Context, user_id: int) -> None:
         user_id: The unique identifier of the user who owns the password.
 
     """
-    password_dao: PasswordDAO = ctx.obj["password_dao"]
     db_client: DBClient = ctx.obj["db_client_instance"]
     password_dao = PasswordDAO(db_client, user_id)
     passwords = asyncio.run(password_dao.get_all())

--- a/backend/src/keychain/utils/cli/db_client/password.py
+++ b/backend/src/keychain/utils/cli/db_client/password.py
@@ -9,6 +9,7 @@ import click
 
 from keychain.modules.routers.models.response import PasswordGetResponseModel, PasswordGetResponseModelSimple
 from keychain.services.daos import PasswordDAO
+from keychain.services.db_client.client import DBClient
 
 
 @click.group(help="CLI for managing passwords of the Keychain Application.")
@@ -39,15 +40,18 @@ def create_password(ctx: click.Context, name: str, user_id: int, image_url: str 
 
     """
     password_dao: PasswordDAO = ctx.obj["password_dao"]
-    password = asyncio.run(password_dao.create(name, user_id, image_url))
+    db_client: DBClient = ctx.obj["db_client_instance"]
+    password_dao = PasswordDAO(db_client, user_id)
+    password = asyncio.run(password_dao.create(name, image_url))
     password_response = PasswordGetResponseModel.model_validate(password)
     click.echo(password_response.model_dump_json(indent=2))
 
 
 @password.command(help="Get a password by ID")
 @click.option("--password-id", prompt="Enter the password ID", help="The ID of the password", type=int)
+@click.option("--user-id", prompt="Enter the user ID", help="The ID of the user who owns the password", type=int)
 @click.pass_context
-def get_password(ctx: click.Context, password_id: int) -> None:
+def get_password(ctx: click.Context, password_id: int, user_id: int) -> None:
     """Retrieve a password from the database by its ID.
 
     This command fetches a password record by ID and outputs the password information
@@ -56,9 +60,12 @@ def get_password(ctx: click.Context, password_id: int) -> None:
     Args:
         ctx: Click context object containing the password DAO.
         password_id: The unique identifier of the password to retrieve.
+        user_id: The unique identifier of the user who owns the password.
 
     """
     password_dao: PasswordDAO = ctx.obj["password_dao"]
+    db_client: DBClient = ctx.obj["db_client_instance"]
+    password_dao = PasswordDAO(db_client, user_id)
     password = asyncio.run(password_dao.get_by_id(password_id))
     password_response = PasswordGetResponseModel.model_validate(password)
     click.echo(password_response.model_dump_json(indent=2))
@@ -68,8 +75,9 @@ def get_password(ctx: click.Context, password_id: int) -> None:
 @click.option("--password-id", prompt="Enter the password ID", help="The ID of the password", type=int)
 @click.option("--name", prompt="Enter the new name", help="The new name of the password")
 @click.option("--image-url", default=None, help="The new image URL of the password")
+@click.option("--user-id", prompt="Enter the user ID", help="The ID of the user who owns the password", type=int)
 @click.pass_context
-def update_password(ctx: click.Context, password_id: int, name: str, image_url: str | None) -> None:
+def update_password(ctx: click.Context, password_id: int, name: str, image_url: str | None, user_id: int) -> None:
     """Update a password's name and/or image URL in the database.
 
     This command updates the name and/or image URL of an existing password identified
@@ -80,9 +88,12 @@ def update_password(ctx: click.Context, password_id: int, name: str, image_url: 
         password_id: The unique identifier of the password to update.
         name: The new name to assign to the password.
         image_url: Optional new image URL to assign to the password.
+        user_id: The unique identifier of the user who owns the password.
 
     """
     password_dao: PasswordDAO = ctx.obj["password_dao"]
+    db_client: DBClient = ctx.obj["db_client_instance"]
+    password_dao = PasswordDAO(db_client, user_id)
     password = asyncio.run(password_dao.update(password_id, name, image_url))
     password_response = PasswordGetResponseModel.model_validate(password)
     click.echo(password_response.model_dump_json(indent=2))
@@ -90,8 +101,9 @@ def update_password(ctx: click.Context, password_id: int, name: str, image_url: 
 
 @password.command(help="Delete a password by ID")
 @click.option("--password-id", prompt="Enter the password ID", help="The ID of the password", type=int)
+@click.option("--user-id", prompt="Enter the user ID", help="The ID of the user who owns the password", type=int)
 @click.pass_context
-def delete_password(ctx: click.Context, password_id: int) -> None:
+def delete_password(ctx: click.Context, password_id: int, user_id: int) -> None:
     """Delete a password from the database by its ID.
 
     This command permanently removes a password record from the database.
@@ -100,16 +112,20 @@ def delete_password(ctx: click.Context, password_id: int) -> None:
     Args:
         ctx: Click context object containing the password DAO.
         password_id: The unique identifier of the password to delete.
+        user_id: The unique identifier of the user who owns the password.
 
     """
     password_dao: PasswordDAO = ctx.obj["password_dao"]
+    db_client: DBClient = ctx.obj["db_client_instance"]
+    password_dao = PasswordDAO(db_client, user_id)
     asyncio.run(password_dao.delete(password_id))
     click.echo(f"Password with id {password_id} deleted successfully")
 
 
 @password.command(help="List all passwords")
+@click.option("--user-id", prompt="Enter the user ID", help="The ID of the user who owns the password", type=int)
 @click.pass_context
-def list_passwords(ctx: click.Context) -> None:
+def list_passwords(ctx: click.Context, user_id: int) -> None:
     """List all passwords in the database.
 
     This command retrieves all passwords from the database and outputs them
@@ -117,9 +133,12 @@ def list_passwords(ctx: click.Context) -> None:
 
     Args:
         ctx: Click context object containing the password DAO.
+        user_id: The unique identifier of the user who owns the password.
 
     """
     password_dao: PasswordDAO = ctx.obj["password_dao"]
+    db_client: DBClient = ctx.obj["db_client_instance"]
+    password_dao = PasswordDAO(db_client, user_id)
     passwords = asyncio.run(password_dao.get_all())
     password_responses = [
         PasswordGetResponseModelSimple.model_validate({"id": pwd.id, "name": pwd.name}) for pwd in passwords

--- a/backend/src/keychain/utils/cli/db_client/user.py
+++ b/backend/src/keychain/utils/cli/db_client/user.py
@@ -9,15 +9,18 @@ from colorama import Fore, Style
 
 from keychain.modules.routers.models.response import UserGetResponseModel
 from keychain.services.daos import UserDAO
+from keychain.services.db_client.client import DBClient
 
 
 @click.group(help="CLI for managing users of the Keychain Application.")
-def user() -> None:
+@click.pass_context
+def user(ctx: click.Context) -> None:
     """Initialize the user CLI group for the Keychain Application.
 
     This function serves as the root command group for all user CLI operations.
     """
-    pass
+    db_client: DBClient = ctx.obj["db_client_instance"]
+    ctx.obj["user_dao"] = UserDAO(db_client)
 
 
 @user.command(help="Create a new user")
@@ -131,3 +134,31 @@ def verify_password(ctx: click.Context, user_id: int, password: str) -> None:
     is_valid_text = "valid" if is_valid else "invalid"
     is_valid_color = Fore.GREEN if is_valid else Fore.RED
     click.echo(f"Password for user with id {user_id} is {is_valid_color}{is_valid_text}{Style.RESET_ALL}")
+
+
+@user.command(help="Reset a user's password by ID")
+@click.option("--user-id", prompt="Enter the user ID", help="The ID of the user")
+@click.option(
+    "--password",
+    prompt="Enter the new password",
+    help="The new password of the user",
+    hide_input=True,
+    confirmation_prompt=True,
+)
+@click.pass_context
+def reset_password(ctx: click.Context, user_id: int, password: str) -> None:
+    """Reset a user's password.
+
+    This command resets the password for an existing user identified by their ID
+    and outputs the updated user information as JSON.
+
+    Args:
+        ctx: Click context object containing the user DAO.
+        user_id: The unique identifier of the user to reset the password for.
+        password: The new password for the user.
+
+    """
+    user_dao: UserDAO = ctx.obj["user_dao"]
+    user = asyncio.run(user_dao.reset_password(user_id, password))
+    user_response = UserGetResponseModel.model_validate(user)
+    click.echo(user_response.model_dump_json(indent=2))

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -8,7 +8,7 @@ http {
 
     server {
         listen 80;
-        server_name localhost;
+        server_name keychain;
 
         root /usr/share/nginx/html/static;
         index index.html;


### PR DESCRIPTION
This pull request introduces several improvements and refactorings to the CLI and backend logic for managing users, passwords, and fields in the Keychain application. The main themes are improved handling of user context in CLI commands, simplification of DAO usage, and the addition of a password reset feature for users.

**Major changes include:**

### CLI and DAO Refactoring

* Refactored CLI commands for fields and passwords to require a `user_id` parameter, ensuring all operations are explicitly tied to a user. The DAOs are now instantiated with both the database client and the user ID in each command, improving clarity and reducing reliance on global state. [[1]](diffhunk://#diff-ea90b2b76fdf526f6ea9cd49c9b09f83a37f5988c480c95c357215f32a0dd340R32-R37) [[2]](diffhunk://#diff-ea90b2b76fdf526f6ea9cd49c9b09f83a37f5988c480c95c357215f32a0dd340R47-R63) [[3]](diffhunk://#diff-ea90b2b76fdf526f6ea9cd49c9b09f83a37f5988c480c95c357215f32a0dd340R72-R77) [[4]](diffhunk://#diff-ea90b2b76fdf526f6ea9cd49c9b09f83a37f5988c480c95c357215f32a0dd340R86-R88) [[5]](diffhunk://#diff-ea90b2b76fdf526f6ea9cd49c9b09f83a37f5988c480c95c357215f32a0dd340R99-R114) [[6]](diffhunk://#diff-ea90b2b76fdf526f6ea9cd49c9b09f83a37f5988c480c95c357215f32a0dd340R123-R149) F4b7bbf3L120R134, [[7]](diffhunk://#diff-06114b15758d7f8f69cce2c9a61e45ed132eccc85616a66037e5af0a28c5312aL42-R54) [[8]](diffhunk://#diff-06114b15758d7f8f69cce2c9a61e45ed132eccc85616a66037e5af0a28c5312aR63-R68) [[9]](diffhunk://#diff-06114b15758d7f8f69cce2c9a61e45ed132eccc85616a66037e5af0a28c5312aR78-R80) [[10]](diffhunk://#diff-06114b15758d7f8f69cce2c9a61e45ed132eccc85616a66037e5af0a28c5312aR91-R106) [[11]](diffhunk://#diff-06114b15758d7f8f69cce2c9a61e45ed132eccc85616a66037e5af0a28c5312aR115-R141) F31e5b11L112R132)
* Updated the CLI context initialization to only store the database client instance, removing pre-instantiated DAOs and instead constructing them as needed per command.

### Backend DAO and API Adjustments

* Modified the `PasswordDAO.create` method to remove `user_id` as a direct parameter, instead using the DAO's internal `user_id` attribute. Updated all usages accordingly in both backend and CLI. [[1]](diffhunk://#diff-279f7bc3dc45964715f983b073c8579fd9e38734faf702d96936cf5a6b9f4018L76-L86) [[2]](diffhunk://#diff-279f7bc3dc45964715f983b073c8579fd9e38734faf702d96936cf5a6b9f4018L96-R95) [[3]](diffhunk://#diff-e325f9a07d69c2f73cf86efbb22faa067487b585c72888c1fdd3944f0fd12a8eL98-R98)

### User Management Enhancements

* Added a new CLI command to reset a user's password by ID, allowing password updates from the command line.
* Updated the user CLI group to initialize and store the `UserDAO` in the context using the shared database client.

### Miscellaneous

* Changed the Nginx configuration to use `server_name keychain` instead of `localhost`.
* Cleaned up unused imports in CLI files. [[1]](diffhunk://#diff-a3df29143aa19037508a2a82dfe42cf8ce5ba42bc949aad13c1a982611cbb831L9) [[2]](diffhunk://#diff-ea90b2b76fdf526f6ea9cd49c9b09f83a37f5988c480c95c357215f32a0dd340R14) [[3]](diffhunk://#diff-06114b15758d7f8f69cce2c9a61e45ed132eccc85616a66037e5af0a28c5312aR12)

These changes collectively make the CLI more robust, user-context aware, and easier to maintain, while also introducing a useful password reset feature for user management.