### PR TITLE
fix: Fix cached passwords

### DIFF
--- a/frontend/src/pages/logout/Logout.tsx
+++ b/frontend/src/pages/logout/Logout.tsx
@@ -1,16 +1,19 @@
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router';
 
+import { usePasswordsStore } from '@store/passwords';
 import { useUserStore } from '@store/user';
 
 export function Logout() {
-  const { removeAccessToken } = useUserStore();
+  const { clearStore } = useUserStore();
+  const { clearStore: clearPasswordStore } = usePasswordsStore();
   const navigate = useNavigate();
 
   useEffect(() => {
-    removeAccessToken();
+    clearStore();
+    clearPasswordStore();
     navigate('/login');
-  }, [navigate, removeAccessToken]);
+  }, [navigate, clearStore, clearPasswordStore]);
 
   return null;
 }

--- a/frontend/src/store/passwords/passwordsStore.ts
+++ b/frontend/src/store/passwords/passwordsStore.ts
@@ -43,5 +43,6 @@ export const usePasswordsStore = create<PasswordStore>()(
         undefined,
         'updateField'
       ),
+    clearStore: () => set({ passwords: [], currentPassword: null }, undefined, 'clearStore'),
   }))
 );

--- a/frontend/src/store/passwords/types.ts
+++ b/frontend/src/store/passwords/types.ts
@@ -29,4 +29,5 @@ export type PasswordStore = {
   addPassword: (password: PasswordSimple) => void;
   addField: (field: PasswordField) => void;
   updateField: (id: number, field: PasswordField) => void;
+  clearStore: () => void;
 };

--- a/frontend/src/store/user/types.ts
+++ b/frontend/src/store/user/types.ts
@@ -11,5 +11,5 @@ export type UserStore = {
   setIsLoading: (isLoading: boolean) => void;
   setAccessToken: (accessToken: string) => void;
   setUser: (user: User) => void;
-  removeAccessToken: () => void;
+  clearStore: () => void;
 };

--- a/frontend/src/store/user/userStore.ts
+++ b/frontend/src/store/user/userStore.ts
@@ -11,9 +11,9 @@ export const useUserStore = create<UserStore>()(
     isLoading: false,
     setIsLoading: (isLoading: boolean) => set({ isLoading }, undefined, 'setIsLoading'),
     setUser: (user: User) => set({ user }, undefined, 'setUser'),
-    removeAccessToken: () => {
+    clearStore: () => {
       Cookies.remove('accessToken');
-      set({ accessToken: null, user: null }, undefined, 'removeAccessToken');
+      set({ accessToken: null, user: null }, undefined, 'clearStore');
     },
     setAccessToken: (accessToken: string) => {
       Cookies.set('accessToken', accessToken);

--- a/frontend/src/utils/apiClient/client.ts
+++ b/frontend/src/utils/apiClient/client.ts
@@ -1,10 +1,12 @@
 import axios, { AxiosError } from 'axios';
 import { useCallback } from 'react';
 
+import { usePasswordsStore } from '@store/passwords';
 import { useUserStore } from '@store/user';
 
 export const useApiGet = () => {
-  const { setIsLoading, accessToken, removeAccessToken } = useUserStore();
+  const { setIsLoading, accessToken, clearStore } = useUserStore();
+  const { clearStore: clearPasswordStore } = usePasswordsStore();
 
   return useCallback(
     async <T>(url: string): Promise<T> => {
@@ -19,7 +21,8 @@ export const useApiGet = () => {
         return response.data;
       } catch (error) {
         if (error instanceof AxiosError && error.response?.status === 401) {
-          removeAccessToken();
+          clearStore();
+          clearPasswordStore();
         } else {
           console.error(error);
         }
@@ -28,12 +31,13 @@ export const useApiGet = () => {
         setIsLoading(false);
       }
     },
-    [accessToken, setIsLoading]
+    [accessToken, setIsLoading, clearStore, clearPasswordStore]
   );
 };
 
 export const useApiPut = () => {
-  const { setIsLoading, accessToken, removeAccessToken } = useUserStore();
+  const { setIsLoading, accessToken, clearStore } = useUserStore();
+  const { clearStore: clearPasswordStore } = usePasswordsStore();
 
   return useCallback(
     async <D, T>(url: string, data: D): Promise<T> => {
@@ -48,7 +52,8 @@ export const useApiPut = () => {
         return response.data;
       } catch (error) {
         if (error instanceof AxiosError && error.response?.status === 401) {
-          removeAccessToken();
+          clearStore();
+          clearPasswordStore();
         } else {
           console.error(error);
         }
@@ -57,12 +62,13 @@ export const useApiPut = () => {
         setIsLoading(false);
       }
     },
-    [accessToken, setIsLoading]
+    [accessToken, setIsLoading, clearStore, clearPasswordStore]
   );
 };
 
 export const useApiPost = () => {
-  const { setIsLoading, accessToken, removeAccessToken } = useUserStore();
+  const { setIsLoading, accessToken, clearStore } = useUserStore();
+  const { clearStore: clearPasswordStore } = usePasswordsStore();
 
   return useCallback(
     async <D, T>(url: string, data: D): Promise<T> => {
@@ -77,7 +83,8 @@ export const useApiPost = () => {
         return response.data;
       } catch (error) {
         if (error instanceof AxiosError && error.response?.status === 401) {
-          removeAccessToken();
+          clearStore();
+          clearPasswordStore();
         } else {
           console.error(error);
         }
@@ -86,7 +93,7 @@ export const useApiPost = () => {
         setIsLoading(false);
       }
     },
-    [accessToken, setIsLoading]
+    [accessToken, setIsLoading, clearStore, clearPasswordStore]
   );
 };
 


### PR DESCRIPTION
This pull request refactors the logout and authentication error handling logic in the frontend to ensure that both user and password-related state are fully cleared on logout or when an unauthorized (401) error occurs. The changes introduce a standardized `clearStore` method for both the user and passwords stores, replacing the previous `removeAccessToken` approach. This helps prevent stale data and improves security by ensuring all sensitive information is purged on logout or session expiration.

**Authentication and State Management Improvements:**

* Replaced the `removeAccessToken` method in the `user` store with a new `clearStore` method that clears both `accessToken` and `user` state, and updated all references accordingly (`frontend/src/store/user/types.ts`, `frontend/src/store/user/userStore.ts`, `frontend/src/pages/logout/Logout.tsx`, `frontend/src/utils/apiClient/client.ts`) [[1]](diffhunk://#diff-b0bf429b5f926df05744de26c7844d48c6c0faa996236da270933e28ed37b619L14-R14) [[2]](diffhunk://#diff-eda0951d570a4f8b906f53f2c548bea72367ac4cb7ea9f04dd60ee7ce1721883L14-R16) [[3]](diffhunk://#diff-0e7a0dd9b43954549069763028e2518e8ddf16f483768fec444be92670fd38f0R4-R16) [[4]](diffhunk://#diff-7cf9f38fe337791e14eacfedcbabad72bbf80829ebb5288e11f9541e95087609R4-R9).
* Added a `clearStore` method to the `passwords` store to reset all password-related state, and updated the type definitions and usages to include this method (`frontend/src/store/passwords/types.ts`, `frontend/src/store/passwords/passwordsStore.ts`, `frontend/src/pages/logout/Logout.tsx`, `frontend/src/utils/apiClient/client.ts`) [[1]](diffhunk://#diff-ade4db1f0a745773f32b7acf9c228731c65f5c08ccb3e86f655b347618d683f8R32) [[2]](diffhunk://#diff-eb7a756f3d34f7a2caee15bcb37f1a98d46afd2f5048743310dca899f0eb5b1dR46) [[3]](diffhunk://#diff-0e7a0dd9b43954549069763028e2518e8ddf16f483768fec444be92670fd38f0R4-R16) [[4]](diffhunk://#diff-7cf9f38fe337791e14eacfedcbabad72bbf80829ebb5288e11f9541e95087609R4-R9).

**Logout and Error Handling Enhancements:**

* Updated the logout page (`Logout.tsx`) to clear both the user and passwords stores when logging out, ensuring all sensitive data is removed from the client state.
* Refactored API client hooks (`useApiGet`, `useApiPut`, `useApiPost`) to use the new `clearStore` methods for both user and passwords stores when a 401 Unauthorized error is encountered, ensuring a consistent and secure state reset [[1]](diffhunk://#diff-7cf9f38fe337791e14eacfedcbabad72bbf80829ebb5288e11f9541e95087609R4-R9) [[2]](diffhunk://#diff-7cf9f38fe337791e14eacfedcbabad72bbf80829ebb5288e11f9541e95087609L22-R25) [[3]](diffhunk://#diff-7cf9f38fe337791e14eacfedcbabad72bbf80829ebb5288e11f9541e95087609L31-R40) [[4]](diffhunk://#diff-7cf9f38fe337791e14eacfedcbabad72bbf80829ebb5288e11f9541e95087609L51-R56) [[5]](diffhunk://#diff-7cf9f38fe337791e14eacfedcbabad72bbf80829ebb5288e11f9541e95087609L60-R71) [[6]](diffhunk://#diff-7cf9f38fe337791e14eacfedcbabad72bbf80829ebb5288e11f9541e95087609L80-R87) [[7]](diffhunk://#diff-7cf9f38fe337791e14eacfedcbabad72bbf80829ebb5288e11f9541e95087609L89-R96).