### PR TITLE
feat: Add ssl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+nginx/ssl/
 scripts/
 static/

--- a/docker-compose.local.yaml
+++ b/docker-compose.local.yaml
@@ -6,9 +6,11 @@ services:
     container_name: keychain-nginx
     ports:
       - 80:80
+      - 443:443
     volumes:
-      - ./nginx/nginx.conf:/etc/nginx/nginx.conf
+      - ./nginx/config/nginx.conf:/etc/nginx/nginx.conf
       - ./static:/usr/share/nginx/html/static
+      - ./nginx/ssl:/etc/nginx/ssl
     depends_on:
       - backend
 

--- a/nginx/config/nginx.conf
+++ b/nginx/config/nginx.conf
@@ -9,7 +9,22 @@ http {
     server {
         listen 80;
         server_name keychain;
+        # Optional: Redirect HTTP to HTTPS
+        return 301 https://$host$request_uri;
+    }
 
+    server {
+        listen 443 ssl;
+        listen [::]:443 ssl;
+        server_name keychain;
+
+        ssl_certificate /etc/nginx/ssl/keychain.pem;
+        ssl_certificate_key /etc/nginx/ssl/keychain.key;
+
+        # Recommended security settings
+        ssl_protocols TLSv1.2 TLSv1.3;
+        ssl_prefer_server_ciphers on;
+        
         root /usr/share/nginx/html/static;
         index index.html;
 


### PR DESCRIPTION
This pull request updates the local development environment to support HTTPS by configuring Nginx for SSL and updating related file paths. The changes ensure that HTTP traffic is redirected to HTTPS and that the necessary SSL certificates are mounted into the container.

**Nginx SSL/HTTPS configuration:**

* Added a new server block in `nginx/config/nginx.conf` to listen on port 443 with SSL enabled, including configuration for SSL certificates and recommended security settings.
* Configured HTTP (port 80) to redirect all requests to HTTPS for improved security.

**Docker Compose adjustments:**

* Exposed port 443 in the `keychain-nginx` service and mounted the SSL certificate directory and updated Nginx config path in `docker-compose.local.yaml`.