### PR TITLE
feat: Add auto versioning

### DIFF
--- a/.github/scripts/bump_version.py
+++ b/.github/scripts/bump_version.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Version bumping script for keychain project.
+
+Handles version bumping for both Python (__init__.py) and JSON (package.json) files.
+"""
+
+import argparse
+import json
+import logging
+import re
+import sys
+from pathlib import Path
+from typing import Tuple
+
+logger = logging.getLogger(__name__)
+
+
+def parse_version(version_string: str) -> Tuple[int, int, int]:
+    """Parse semantic version string into major, minor, patch components.
+
+    Args:
+        version_string: Version string in format "X.Y.Z"
+
+    Returns:
+        Tuple of (major, minor, patch) as integers
+
+    """
+    match = re.match(r"^(\d+)\.(\d+)\.(\d+)$", version_string)
+    if not match:
+        raise ValueError(f"Invalid version format: {version_string}")
+    return int(match.group(1)), int(match.group(2)), int(match.group(3))
+
+
+def format_version(major: int, minor: int, patch: int) -> str:
+    """Format version components into semantic version string."""
+    return f"{major}.{minor}.{patch}"
+
+
+def bump_version(version_string: str, branch: str) -> str:
+    """Bump version based on branch name.
+
+    Args:
+        version_string: Current version string
+        branch: Git branch name (development or master)
+
+    Returns:
+        New bumped version string
+
+    """
+    major, minor, patch = parse_version(version_string)
+
+    if branch == "development":
+        # Bump PATCH version for development branch
+        patch += 1
+    elif branch == "master":
+        # Bump MINOR version for master branch
+        minor += 1
+        patch = 0  # Reset patch when bumping minor
+    else:
+        raise ValueError(f"Unsupported branch: {branch}")
+
+    return format_version(major, minor, patch)
+
+
+def get_python_version(file_path: Path) -> str:
+    """Extract version from Python __init__.py file.
+
+    Expected format: __version__ = "X.Y.Z"
+    """
+    content = file_path.read_text()
+    match = re.search(r'__version__\s*=\s*["\']([^"\']+)["\']', content)
+    if not match:
+        raise ValueError(f"Could not find __version__ in {file_path}")
+    return match.group(1)
+
+
+def set_python_version(file_path: Path, new_version: str) -> None:
+    """Update version in Python __init__.py file."""
+    content = file_path.read_text()
+    new_content = re.sub(r'(__version__\s*=\s*["\'])[^"\']+(["\'])', rf"\g<1>{new_version}\g<2>", content)
+    file_path.write_text(new_content)
+
+
+def get_json_version(file_path: Path) -> str:
+    """Extract version from JSON file (package.json)."""
+    data = json.loads(file_path.read_text())
+    if "version" not in data:
+        raise ValueError(f"Could not find version field in {file_path}")
+    return data["version"]
+
+
+def set_json_version(file_path: Path, new_version: str) -> None:
+    """Update version in JSON file (package.json)."""
+    data = json.loads(file_path.read_text())
+    data["version"] = new_version
+    file_path.write_text(json.dumps(data, indent=2) + "\n")
+
+
+def main():
+    """Main entry point for version bumping script."""
+    parser = argparse.ArgumentParser(description="Bump version in project files")
+    parser.add_argument("--file", required=True, type=Path, help="Path to file to update")
+    parser.add_argument("--type", required=True, choices=["python", "json"], help="Type of file to update")
+    parser.add_argument("--branch", help="Branch name (development or master)")
+    parser.add_argument("--get-version", action="store_true", help="Only get current version without bumping")
+
+    args = parser.parse_args()
+
+    # Get current version based on file type
+    if args.type == "python":
+        current_version = get_python_version(args.file)
+    elif args.type == "json":
+        current_version = get_json_version(args.file)
+    else:
+        logger.error(f"Unsupported file type: {args.type}")
+        sys.exit(1)
+
+    # If only getting version, print and exit
+    if args.get_version:
+        logger.info(current_version)
+        return
+
+    # Validate branch argument is provided for bumping
+    if not args.branch:
+        logger.error("--branch is required when not using --get-version")
+        sys.exit(1)
+
+    # Bump version
+    try:
+        new_version = bump_version(current_version, args.branch)
+    except ValueError as e:
+        logger.error(f"Error: {e}")
+        sys.exit(1)
+
+    # Update file with new version
+    if args.type == "python":
+        set_python_version(args.file, new_version)
+    elif args.type == "json":
+        set_json_version(args.file, new_version)
+
+    logger.info(f"Version bumped: {current_version} -> {new_version}")
+    logger.info(f"File updated: {args.file}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/version_bump.yml
+++ b/.github/workflows/version_bump.yml
@@ -1,0 +1,141 @@
+name: version-bump
+
+on:
+  push:
+    branches:
+      - development
+      - master
+    paths:
+      - "backend/**"
+      - "frontend/**"
+
+jobs:
+  bump-backend-version:
+    runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[version bump]') }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check if backend files changed
+        id: check-backend
+        run: |
+          CHANGED_FILES=$(git diff --name-only HEAD^ HEAD)
+          if echo "$CHANGED_FILES" | grep -q "^backend/"; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "changed=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Setup Python
+        if: steps.check-backend.outputs.changed == 'true'
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Bump backend version
+        if: steps.check-backend.outputs.changed == 'true'
+        run: |
+          python .github/scripts/bump_version.py \
+            --file backend/src/keychain/__init__.py \
+            --type python \
+            --branch ${{ github.ref_name }}
+
+      - name: Get new version
+        if: steps.check-backend.outputs.changed == 'true'
+        id: get-version
+        run: |
+          VERSION=$(python .github/scripts/bump_version.py --file backend/src/keychain/__init__.py --type python --get-version)
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Commit and push backend version
+        if: steps.check-backend.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git add backend/src/keychain/__init__.py
+          git commit -m "chore: bump backend version to ${{ steps.get-version.outputs.version }} [version bump]"
+          git tag -a "backend-v${{ steps.get-version.outputs.version }}" -m "Backend release v${{ steps.get-version.outputs.version }}"
+          git push origin ${{ github.ref_name }}
+          git push origin "backend-v${{ steps.get-version.outputs.version }}"
+
+      - name: Create GitHub Release
+        if: steps.check-backend.outputs.changed == 'true' && github.ref_name == 'master'
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: backend-v${{ steps.get-version.outputs.version }}
+          name: Backend v${{ steps.get-version.outputs.version }}
+          draft: false
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  bump-frontend-version:
+    runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[version bump]') }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check if frontend files changed
+        id: check-frontend
+        run: |
+          CHANGED_FILES=$(git diff --name-only HEAD^ HEAD)
+          if echo "$CHANGED_FILES" | grep -q "^frontend/"; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "changed=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Setup Python
+        if: steps.check-frontend.outputs.changed == 'true'
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Bump frontend version
+        if: steps.check-frontend.outputs.changed == 'true'
+        run: |
+          python .github/scripts/bump_version.py \
+            --file frontend/package.json \
+            --type json \
+            --branch ${{ github.ref_name }}
+
+      - name: Get new version
+        if: steps.check-frontend.outputs.changed == 'true'
+        id: get-version
+        run: |
+          VERSION=$(python .github/scripts/bump_version.py --file frontend/package.json --type json --get-version)
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Commit and push frontend version
+        if: steps.check-frontend.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git add frontend/package.json
+          git commit -m "chore: bump frontend version to ${{ steps.get-version.outputs.version }} [version bump]"
+          git tag -a "frontend-v${{ steps.get-version.outputs.version }}" -m "Frontend release v${{ steps.get-version.outputs.version }}"
+          git push origin ${{ github.ref_name }}
+          git push origin "frontend-v${{ steps.get-version.outputs.version }}"
+
+      - name: Create GitHub Release
+        if: steps.check-frontend.outputs.changed == 'true' && github.ref_name == 'master'
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: frontend-v${{ steps.get-version.outputs.version }}
+          name: Frontend v${{ steps.get-version.outputs.version }}
+          draft: false
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 nginx/ssl/
-scripts/
-static/
+/scripts/
+/static/


### PR DESCRIPTION
This pull request introduces automated version bumping for both the backend and frontend projects whenever changes are pushed to the `development` or `master` branches. It adds a new GitHub Actions workflow that detects changes in the respective directories, bumps the version according to branch rules, commits and tags the new version, and creates a GitHub release for production releases. The most important changes are summarized below:

**CI/CD Automation:**

* Added `.github/workflows/version_bump.yml` workflow to automate version bumping, tagging, and release creation for both backend and frontend projects based on branch and file changes.

**Version Bumping Logic:**

* Introduced `.github/scripts/bump_version.py`, a Python script that handles semantic version bumping for both Python (`__init__.py`) and JSON (`package.json`) files, with logic to increment patch for `development` and minor for `master` branches.

**Backend Version Management:**

* Automated detection of backend changes and version bumping in `backend/src/keychain/__init__.py`, including tagging and release creation on `master`.

**Frontend Version Management:**

* Automated detection of frontend changes and version bumping in `frontend/package.json`, including tagging and release creation on `master`.